### PR TITLE
fix(restore): silence spawned process stdout/stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.1] - 2026-03-11
+
+### Fixed
+
+- Redirect spawned process stdout/stderr to /dev/null during restore, preventing noisy child process output from flooding the terminal
+
+---
+
 ## [0.2.0] - 2026-03-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyprflow"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprflow"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Save and restore Hyprland window sessions"
 license = "MIT"

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::hyprctl::{HyprctlClient, HyprctlError};
 use crate::session::{Session, SessionClient};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -180,6 +180,8 @@ pub fn restore_session(
                 // Launch brave with profile directory.
                 let spawn_result = Command::new(&binary)
                     .arg(format!("--profile-directory={}", profile.directory))
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .spawn();
 
                 match spawn_result {
@@ -262,6 +264,8 @@ fn restore_single_client(
     let launch_cmd = build_launch_command(client);
     Command::new(&launch_cmd[0])
         .args(&launch_cmd[1..])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .map_err(|e| {
             HyprctlError::CommandFailed(format!("spawn '{}' failed: {e}", client.launch.command))


### PR DESCRIPTION
## Summary

- Redirect child process stdout/stderr to `/dev/null` during `hyprflow restore`
- Prevents noisy output from Brave (IPH errors, Wayland/Vulkan warnings, etc.) and kitty (glfw/fontconfig errors) from flooding the user's terminal
- Bumps version to 0.2.1

## Test plan

- [x] `cargo test` — 70 tests pass (64 unit + 6 integration)
- [x] `cargo clippy` — no new warnings
- [x] `cargo build --release` — compiles cleanly
- [ ] Manual test: `hyprflow restore` should show only hyprflow's own output, no child process stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)